### PR TITLE
Swapping PSETEX for SETEX

### DIFF
--- a/simplekv/memory/redisstore.py
+++ b/simplekv/memory/redisstore.py
@@ -48,7 +48,7 @@ class RedisStore(TimeToLiveMixin, KeyValueStore):
             # to set a default timeout on keys
             self.redis.set(key, value)
         else:
-            self.redis.psetex(key, int(ttl_secs * 1000), value)
+            self.redis.setex(key, int(ttl_secs), value)
         return key
 
     def _put_file(self, key, file, ttl_secs):


### PR DESCRIPTION
Swapping PSETEX for SETEX because we don't lose any functionality and make the code REDIS 2.4 compliant.
